### PR TITLE
chore: Upgrade codeql-action to version 4

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -73,6 +73,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
See deprecation notice at: https://github.blog/changelog/2025-10-28-upcoming-deprecation-of-codeql-action-v3/